### PR TITLE
Correct Apache 2 headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,3 @@
-## Copyright (c) 2020 T-Mobile
-##
-## Licensed under the Apache License, Version 2.0 (the "License"); you
-## may not use this file except in compliance with the License.  You
-## may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-## implied.  See the License for the specific language governing
-## permissions and limitations under the License.
-
 # Packages to test; can be overridden at the command line
 PACKAGES    = ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-## Copyright (c) 2020 Kevin L. Mitchell
+## Copyright (c) 2020 T-Mobile
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License"); you
 ## may not use this file except in compliance with the License.  You

--- a/common.go
+++ b/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/common_test.go
+++ b/common_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/mocks.go
+++ b/mocks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/parallel.go
+++ b/parallel.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/serial.go
+++ b/serial.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/serial_test.go
+++ b/serial_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/synchronous.go
+++ b/synchronous.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You

--- a/synchronous_test.go
+++ b/synchronous_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Kevin L. Mitchell
+// Copyright (c) 2020 T-Mobile
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you
 // may not use this file except in compliance with the License.  You


### PR DESCRIPTION
Now that this has been adopted by T-Mobile, the file license headers have to be updated to state that.