### PR TITLE
Fix refs and update `go.mod`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,22 @@
 Parallelizer
 ============
 
-.. image:: https://img.shields.io/github/tag/klmitch/parallelizer.svg
-    :target: https://github.com/klmitch/parallelizer/tags
+.. image:: https://img.shields.io/github/tag/tmobile/parallelizer.svg
+    :target: https://github.com/tmobile/parallelizer/tags
 .. image:: https://img.shields.io/hexpm/l/plug.svg
-    :target: https://github.com/klmitch/parallelizer/blob/master/LICENSE
-.. image:: https://travis-ci.org/klmitch/parallelizer.svg?branch=master
-    :target: https://travis-ci.org/klmitch/parallelizer
-.. image:: https://coveralls.io/repos/github/klmitch/parallelizer/badge.svg?branch=master
-    :target: https://coveralls.io/github/klmitch/parallelizer?branch=master
-.. image:: https://godoc.org/github.com/klmitch/parallelizer?status.svg
-    :target: http://godoc.org/github.com/klmitch/parallelizer
-.. image:: https://img.shields.io/github/issues/klmitch/parallelizer.svg
-    :target: https://github.com/klmitch/parallelizer/issues
-.. image:: https://img.shields.io/github/issues-pr/klmitch/parallelizer.svg
-    :target: https://github.com/klmitch/parallelizer/pulls
-.. image:: https://goreportcard.com/badge/github.com/klmitch/parallelizer
-    :target: https://goreportcard.com/report/github.com/klmitch/parallelizer
+    :target: https://github.com/tmobile/parallelizer/blob/master/LICENSE
+.. image:: https://travis-ci.org/tmobile/parallelizer.svg?branch=master
+    :target: https://travis-ci.org/tmobile/parallelizer
+.. image:: https://coveralls.io/repos/github/tmobile/parallelizer/badge.svg?branch=master
+    :target: https://coveralls.io/github/tmobile/parallelizer?branch=master
+.. image:: https://godoc.org/github.com/tmobile/parallelizer?status.svg
+    :target: http://godoc.org/github.com/tmobile/parallelizer
+.. image:: https://img.shields.io/github/issues/tmobile/parallelizer.svg
+    :target: https://github.com/tmobile/parallelizer/issues
+.. image:: https://img.shields.io/github/issues-pr/tmobile/parallelizer.svg
+    :target: https://github.com/tmobile/parallelizer/pulls
+.. image:: https://goreportcard.com/badge/github.com/tmobile/parallelizer
+    :target: https://goreportcard.com/report/github.com/tmobile/parallelizer
 
 This repository contains Parallelizer.  Parallelizer is a library for
 enabling the addition of controlled parallelization utilizing a pool

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/klmitch/parallelizer
+module github.com/tmobile/parallelizer
 
-go 1.13
+go 1.14
 
-require github.com/stretchr/testify v1.4.0
+require github.com/stretchr/testify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -4,9 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
+github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Does what it says on the tin.

As an aside, might be better to have the `Makefile` look for goimports/golint/goveralls executables in $PATH and have the README state that, instead of assuming a local TOOLS directory - raised #3 to track that.